### PR TITLE
Drop some materials when destroying wagons

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -87,7 +87,7 @@ machine_parts = {
 }
 
 -- Get material name translating machine_parts material names
-local function get_material(name)
+function machine_parts.get_material(name)
 	if name == "" or name:find(":") then
 		-- Return material as is if name contains colon
 		return name
@@ -96,6 +96,7 @@ local function get_material(name)
 	assert(machine_parts.materials[name], "Attempt to use unavailable material "..name)
 	return machine_parts.materials[name]
 end
+local get_material = machine_parts.get_material
 
 -- Translate recipe materials
 function machine_parts.recipe(data)

--- a/recipes/advtrains_railbus.lua
+++ b/recipes/advtrains_railbus.lua
@@ -1,4 +1,6 @@
 
+local get_material = machine_parts.get_material
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:engine_railbus",
@@ -8,3 +10,9 @@ machine_parts.register_craft({
 		{"advtrains:wheel", "engine_block", "advtrains:wheel"},
 	},
 })
+
+minetest.registered_entities["advtrains:engine_railbus"].drops = {
+	get_material("engine_block"),
+	get_material("dashboard"),
+	get_material("advtrains:wheel") .. " 2",
+}

--- a/recipes/advtrains_train_industrial.lua
+++ b/recipes/advtrains_train_industrial.lua
@@ -1,4 +1,6 @@
 
+local get_material = machine_parts.get_material
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:engine_industrial",
@@ -8,6 +10,13 @@ machine_parts.register_craft({
 		{"advtrains:wheel", "drive_shaft", "advtrains:wheel"}
 	}
 })
+
+minetest.registered_entities["advtrains:engine_industrial"].drops = {
+	get_material("engine_block"),
+	get_material("dashboard"),
+	get_material("gearbox"),
+	get_material("advtrains:wheel") .. " 2",
+}
 
 machine_parts.register_craft({
 	clear_craft = true,
@@ -19,6 +28,13 @@ machine_parts.register_craft({
 	}
 })
 
+minetest.registered_entities["advtrains:engine_industrial_big"].drops = {
+	get_material("engine_block") .. " 2",
+	get_material("dashboard"),
+	get_material("gearbox"),
+	get_material("advtrains:wheel") .. " 3",
+}
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:wagon_tank",
@@ -29,6 +45,11 @@ machine_parts.register_craft({
 	}
 })
 
+minetest.registered_entities["advtrains:wagon_tank"].drops = {
+	get_material("stainless_steel_block") .. " 2",
+	get_material("advtrains:wheel") .. " 2",
+}
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:wagon_wood",
@@ -38,3 +59,8 @@ machine_parts.register_craft({
 		{"advtrains:wheel", "dye_red", "advtrains:wheel"}
 	}
 })
+
+minetest.registered_entities["advtrains:wagon_wood"].drops = {
+	get_material("steel_block"),
+	get_material("advtrains:wheel") .. " 2",
+}

--- a/recipes/advtrains_train_japan.lua
+++ b/recipes/advtrains_train_japan.lua
@@ -1,4 +1,6 @@
 
+local get_material = machine_parts.get_material
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:engine_japan",
@@ -9,6 +11,13 @@ machine_parts.register_craft({
 	}
 })
 
+minetest.registered_entities["advtrains:engine_japan"].drops = {
+	get_material("engine_block"),
+	get_material("dashboard"),
+	get_material("gearbox"),
+	get_material("advtrains:wheel") .. " 3",
+}
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:wagon_japan",
@@ -18,3 +27,8 @@ machine_parts.register_craft({
 		{"advtrains:wheel", "advtrains:wheel", "advtrains:wheel"}
 	}
 })
+
+minetest.registered_entities["advtrains:wagon_japan"].drops = {
+	get_material("wagon_frame"),
+	get_material("advtrains:wheel") .. " 3",
+}

--- a/recipes/advtrains_train_subway.lua
+++ b/recipes/advtrains_train_subway.lua
@@ -1,4 +1,6 @@
 
+local get_material = machine_parts.get_material
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:subway_wagon",
@@ -8,3 +10,10 @@ machine_parts.register_craft({
 		{"advtrains:wheel", "drive_shaft", "advtrains:wheel"},
 	},
 })
+
+minetest.registered_entities["advtrains:subway_wagon"].drops = {
+	get_material("engine_block"),
+	get_material("dashboard"),
+	get_material("gearbox"),
+	get_material("advtrains:wheel") .. " 2",
+}

--- a/recipes/linetrack.lua
+++ b/recipes/linetrack.lua
@@ -1,4 +1,6 @@
 
+local get_material = machine_parts.get_material
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:boat",
@@ -9,6 +11,13 @@ machine_parts.register_craft({
 	},
 })
 
+minetest.registered_entities["advtrains:boat"].drops = {
+	get_material("engine_block"),
+	get_material("dashboard"),
+	get_material("gearbox"),
+	get_material("stainless_steel_block") .. " 2",
+}
+
 machine_parts.register_craft({
 	clear_craft = true,
 	output = "advtrains:bus",
@@ -18,3 +27,9 @@ machine_parts.register_craft({
 		{"rubber", "drive_shaft", "rubber"},
 	},
 })
+
+minetest.registered_entities["advtrains:bus"].drops = {
+	get_material("engine_block"),
+	get_material("dashboard"),
+	get_material("gearbox"),
+}

--- a/spec/fixtures/advtrains.lua
+++ b/spec/fixtures/advtrains.lua
@@ -1,0 +1,21 @@
+
+-- Add fake wagon data for drop overrides
+
+local function addwagon(name)
+	minetest.register_entity(":"..name, {})
+end
+
+addwagon("advtrains:engine_railbus")
+
+addwagon("advtrains:engine_industrial")
+addwagon("advtrains:engine_industrial_big")
+addwagon("advtrains:wagon_tank")
+addwagon("advtrains:wagon_wood")
+
+addwagon("advtrains:engine_japan")
+addwagon("advtrains:wagon_japan")
+
+addwagon("advtrains:subway_wagon")
+
+addwagon("advtrains:boat")
+addwagon("advtrains:bus")

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -1,6 +1,7 @@
 require("mineunit")
 
 mineunit("core")
+fixture("advtrains")
 
 -- Override index lookup to make every item available
 local old_registered_items = minetest.registered_items

--- a/spec/materials_spec.lua
+++ b/spec/materials_spec.lua
@@ -1,6 +1,7 @@
 require("mineunit")
 
 mineunit("core")
+fixture("advtrains")
 
 -- Override index lookup to make every item available
 local old_registered_items = minetest.registered_items


### PR DESCRIPTION
Adds overrides for drops, drop actual materials used for crafting instead of dropping 1-4 steel blocks.

Destroying wagons and engines is still very expensive, only some components can be scrapped for recycling.

Closes #13 